### PR TITLE
Style/#29/shared-styles-cleanup

### DIFF
--- a/src/styles/shared.styles.ts
+++ b/src/styles/shared.styles.ts
@@ -109,4 +109,9 @@ export const PageContainer = styled.div`
   width: 100%;
   margin: 0 auto;
   padding: 60px 20px 100px;
+  box-sizing: border-box;
+
+  @media (min-width: 768px) {
+    padding-top: 80px;
+  }
 `;


### PR DESCRIPTION
## Summary
- MarkdownBody 패딩을 간소화하고 breakpoint별 좌우 패딩 대신 `padding: 12px 0` + 반응형 font-size로 변경
- PageContainer에 `box-sizing: border-box`와 태블릿 이상 반응형 상단 패딩 추가

> `'use client'` 디렉티브 추가는 #27 PR에서 처리 완료

closes #29

## Test plan
- [ ] `pnpm build && pnpm lint` 통과 확인
- [ ] 블로그/포트폴리오 상세 페이지 마크다운 영역 패딩 정상 확인
- [ ] 모바일/태블릿/데스크톱 반응형 레이아웃 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)