### PR TITLE
Fix/#60/scroll-reset-on-navigate

### DIFF
--- a/src/components/common/ScrollToTop.tsx
+++ b/src/components/common/ScrollToTop.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+function ScrollToTop() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}
+
+export default ScrollToTop;

--- a/src/components/common/layout/AppLayout.tsx
+++ b/src/components/common/layout/AppLayout.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from 'react';
 import styled from '@emotion/styled';
 import { NavBar } from '@/components/common/layout/NavBar';
 import { Footer } from '@/components/common/layout/Footer';
+import ScrollToTop from '@/components/common/ScrollToTop';
 import { theme } from '@/styles/theme';
 
 const RootContainer = styled.div`
@@ -36,6 +37,7 @@ interface AppLayoutProps {
 function AppLayout({ children }: AppLayoutProps) {
   return (
     <RootContainer>
+      <ScrollToTop />
       <NavBar />
       <MainContent>
         <Container className="container">{children}</Container>


### PR DESCRIPTION
### 🍥 ISSUE

- closed #60

---

### 🍥 Key Changes

- `ScrollToTop` 컴포넌트 생성 (pathname 변경 감지 → `window.scrollTo(0, 0)`)
- AppLayout에 적용하여 모든 페이지 이동 시 스크롤 초기화

---

### 🍥 ScreenShot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic page scroll-to-top functionality when users navigate between different routes. This enhancement ensures that page content always starts from the top when transitioning to a new page, eliminating the need for manual scrolling and providing a more seamless and consistent browsing experience throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->