### PR TITLE
Chore/#62/notion-api-performance

### DIFF
--- a/src/app/api/blog/[id]/route.ts
+++ b/src/app/api/blog/[id]/route.ts
@@ -1,8 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getBlogPost } from '@/services/blog.service';
-import { REVALIDATE_DETAIL } from '@/constants/cache';
-
-export const revalidate = REVALIDATE_DETAIL;
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;

--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -1,24 +1,19 @@
-﻿import { NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
-import { BLOG_DB_ID, isFullPage, notion, parseBlogPost } from '@/utils/notion';
+import { BLOG_DB_ID, getDataSourceId, isFullPage, notion, parseBlogPost } from '@/utils/notion';
+import { unstable_cache } from 'next/cache';
 import { REVALIDATE_LIST } from '@/constants/cache';
 
-export const revalidate = REVALIDATE_LIST;
-
-export async function GET() {
-  if (!BLOG_DB_ID) {
-    return NextResponse.json({ error: 'Missing NOTION_DATABASE_ID' }, { status: 500 });
-  }
-
-  try {
+const getCachedBlogList = unstable_cache(
+  async () => {
     const dbResponse = await notion.databases.retrieve({
       database_id: BLOG_DB_ID,
     });
 
-    const dataSourceId = (dbResponse as any).data_sources?.[0]?.id;
+    const dataSourceId = getDataSourceId(dbResponse);
 
     if (!dataSourceId) {
-      return NextResponse.json({ error: 'Data Source ID not found' }, { status: 404 });
+      return null;
     }
 
     const response = await notion.dataSources.query({
@@ -31,7 +26,23 @@ export async function GET() {
       ],
     });
 
-    const posts = response.results.filter(isFullPage).map((post: PageObjectResponse) => parseBlogPost(post));
+    return response.results.filter(isFullPage).map((post: PageObjectResponse) => parseBlogPost(post));
+  },
+  ['blog-list'],
+  { revalidate: REVALIDATE_LIST },
+);
+
+export async function GET() {
+  if (!BLOG_DB_ID) {
+    return NextResponse.json({ error: 'Missing NOTION_DATABASE_ID' }, { status: 500 });
+  }
+
+  try {
+    const posts = await getCachedBlogList();
+
+    if (!posts) {
+      return NextResponse.json({ error: 'Data Source ID not found' }, { status: 404 });
+    }
 
     return NextResponse.json(posts);
   } catch (error) {

--- a/src/app/api/portfolio/[id]/route.ts
+++ b/src/app/api/portfolio/[id]/route.ts
@@ -1,8 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getPortfolioPost } from '@/services/portfolio.service';
-import { REVALIDATE_DETAIL } from '@/constants/cache';
-
-export const revalidate = REVALIDATE_DETAIL;
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;

--- a/src/app/api/portfolio/route.ts
+++ b/src/app/api/portfolio/route.ts
@@ -1,24 +1,19 @@
-﻿import { NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
-import { notion, PORTFOLIO_DB_ID, isFullPage, parsePortfolioPage } from '@/utils/notion';
+import { notion, PORTFOLIO_DB_ID, getDataSourceId, isFullPage, parsePortfolioPage } from '@/utils/notion';
+import { unstable_cache } from 'next/cache';
 import { REVALIDATE_LIST } from '@/constants/cache';
 
-export const revalidate = REVALIDATE_LIST;
-
-export async function GET() {
-  if (!PORTFOLIO_DB_ID) {
-    return NextResponse.json({ error: 'Missing NOTION_PORTFOLIO_DB_ID' }, { status: 500 });
-  }
-
-  try {
+const getCachedPortfolioList = unstable_cache(
+  async () => {
     const dbResponse = await notion.databases.retrieve({
       database_id: PORTFOLIO_DB_ID,
     });
 
-    const dataSourceId = (dbResponse as any).data_sources?.[0]?.id;
+    const dataSourceId = getDataSourceId(dbResponse);
 
     if (!dataSourceId) {
-      return NextResponse.json({ error: 'Data Source ID not found in Portfolio DB' }, { status: 404 });
+      return null;
     }
 
     const response = await notion.dataSources.query({
@@ -31,7 +26,23 @@ export async function GET() {
       ],
     });
 
-    const portfolios = response.results.filter(isFullPage).map((post: PageObjectResponse) => parsePortfolioPage(post));
+    return response.results.filter(isFullPage).map((post: PageObjectResponse) => parsePortfolioPage(post));
+  },
+  ['portfolio-list'],
+  { revalidate: REVALIDATE_LIST },
+);
+
+export async function GET() {
+  if (!PORTFOLIO_DB_ID) {
+    return NextResponse.json({ error: 'Missing NOTION_PORTFOLIO_DB_ID' }, { status: 500 });
+  }
+
+  try {
+    const portfolios = await getCachedPortfolioList();
+
+    if (!portfolios) {
+      return NextResponse.json({ error: 'Data Source ID not found in Portfolio DB' }, { status: 404 });
+    }
 
     return NextResponse.json(portfolios);
   } catch (error) {

--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -3,9 +3,8 @@ import { Metadata } from 'next';
 import BlogDetailContent from '@/components/blog/BlogDetailContent';
 import { PageContainer } from '@/styles/shared.styles';
 import { getBlogPost } from '@/services/blog.service';
-import { REVALIDATE_DETAIL } from '@/constants/cache';
 
-export const revalidate = REVALIDATE_DETAIL;
+export const revalidate = 3600;
 
 interface Props {
   params: Promise<{ id: string }>;

--- a/src/app/portfolio/[id]/page.tsx
+++ b/src/app/portfolio/[id]/page.tsx
@@ -3,9 +3,8 @@ import { Metadata } from 'next';
 import PortfolioDetailContent from '@/components/portfolio/PortfolioDetailContent';
 import { PageContainer } from '@/styles/shared.styles';
 import { getPortfolioPost } from '@/services/portfolio.service';
-import { REVALIDATE_DETAIL } from '@/constants/cache';
 
-export const revalidate = REVALIDATE_DETAIL;
+export const revalidate = 3600;
 
 interface PortfolioDetailPageProps {
   params: Promise<{ id: string }>;

--- a/src/components/common/layout/NavBar.tsx
+++ b/src/components/common/layout/NavBar.tsx
@@ -58,6 +58,12 @@ const DesktopMenuGroup = styled.div`
     align-items: center;
     gap: 32px;
   }
+
+  ${theme.media.desktop} {
+    display: flex;
+    align-items: center;
+    gap: 32px;
+  }
 `;
 
 const MenuLabel = styled(Link, {
@@ -83,6 +89,10 @@ const MobileMenuButton = styled.button`
   z-index: 1100;
 
   ${theme.media.tablet} {
+    display: none;
+  }
+
+  ${theme.media.desktop} {
     display: none;
   }
 `;

--- a/src/services/blog.service.ts
+++ b/src/services/blog.service.ts
@@ -1,29 +1,34 @@
-import { cache } from 'react';
+import { unstable_cache } from 'next/cache';
 import { NotionToMarkdown } from 'notion-to-md';
 import { isFullPage, notion, parseBlogPost } from '@/utils/notion';
 import { BlogPostDetail } from '@/types/blog';
+import { REVALIDATE_DETAIL } from '@/constants/cache';
 
 const n2m = new NotionToMarkdown({ notionClient: notion });
 
-export const getBlogPost = cache(async (id: string): Promise<BlogPostDetail | null> => {
-  if (!id) throw new Error('Post ID is required');
+export const getBlogPost = unstable_cache(
+  async (id: string): Promise<BlogPostDetail | null> => {
+    if (!id) throw new Error('Post ID is required');
 
-  try {
-    const [pageResponse, mdBlocks] = await Promise.all([notion.pages.retrieve({ page_id: id }), n2m.pageToMarkdown(id)]);
+    try {
+      const [pageResponse, mdBlocks] = await Promise.all([notion.pages.retrieve({ page_id: id }), n2m.pageToMarkdown(id)]);
 
-    if (!isFullPage(pageResponse)) {
+      if (!isFullPage(pageResponse)) {
+        return null;
+      }
+
+      const metaData = parseBlogPost(pageResponse);
+      const mdString = n2m.toMarkdownString(mdBlocks);
+
+      return {
+        ...metaData,
+        content: mdString.parent,
+      };
+    } catch (error) {
+      console.error(`[BlogService] Failed to fetch post ${id}:`, error);
       return null;
     }
-
-    const metaData = parseBlogPost(pageResponse);
-    const mdString = n2m.toMarkdownString(mdBlocks);
-
-    return {
-      ...metaData,
-      content: mdString.parent,
-    };
-  } catch (error) {
-    console.error(`[BlogService] Failed to fetch post ${id}:`, error);
-    return null;
-  }
-});
+  },
+  ['blog-detail'],
+  { revalidate: REVALIDATE_DETAIL },
+);

--- a/src/services/portfolio.service.ts
+++ b/src/services/portfolio.service.ts
@@ -1,30 +1,35 @@
-import { cache } from 'react';
+import { unstable_cache } from 'next/cache';
 import { NotionToMarkdown } from 'notion-to-md';
 import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 import { isFullPage, notion, parsePortfolioPage } from '@/utils/notion';
 import { PortfolioDetail } from '@/types/portfolio';
+import { REVALIDATE_DETAIL } from '@/constants/cache';
 
 const n2m = new NotionToMarkdown({ notionClient: notion });
 
-export const getPortfolioPost = cache(async (id: string): Promise<PortfolioDetail | null> => {
-  if (!id) throw new Error('Portfolio ID is required');
+export const getPortfolioPost = unstable_cache(
+  async (id: string): Promise<PortfolioDetail | null> => {
+    if (!id) throw new Error('Portfolio ID is required');
 
-  try {
-    const [pageResponse, mdBlocks] = await Promise.all([notion.pages.retrieve({ page_id: id }), n2m.pageToMarkdown(id)]);
+    try {
+      const [pageResponse, mdBlocks] = await Promise.all([notion.pages.retrieve({ page_id: id }), n2m.pageToMarkdown(id)]);
 
-    if (!isFullPage(pageResponse)) {
+      if (!isFullPage(pageResponse)) {
+        return null;
+      }
+
+      const metaData = parsePortfolioPage(pageResponse as PageObjectResponse);
+      const mdString = n2m.toMarkdownString(mdBlocks);
+
+      return {
+        ...metaData,
+        content: mdString.parent,
+      };
+    } catch (error) {
+      console.error(`[PortfolioService] Failed to fetch post ${id}:`, error);
       return null;
     }
-
-    const metaData = parsePortfolioPage(pageResponse as PageObjectResponse);
-    const mdString = n2m.toMarkdownString(mdBlocks);
-
-    return {
-      ...metaData,
-      content: mdString.parent,
-    };
-  } catch (error) {
-    console.error(`[PortfolioService] Failed to fetch post ${id}:`, error);
-    return null;
-  }
-});
+  },
+  ['portfolio-detail'],
+  { revalidate: REVALIDATE_DETAIL },
+);

--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -24,6 +24,15 @@ export const notion = new Client({
 export const BLOG_DB_ID = process.env.NOTION_DB_BLOG_ID || '';
 export const PORTFOLIO_DB_ID = process.env.NOTION_DB_PORTFOLIO_ID || '';
 
+export function getDataSourceId(dbResponse: unknown): string | undefined {
+  const record = dbResponse as Record<string, unknown>;
+  const dataSources = record.data_sources;
+  if (Array.isArray(dataSources) && dataSources.length > 0) {
+    return (dataSources[0] as Record<string, unknown>)?.id as string | undefined;
+  }
+  return undefined;
+}
+
 export function isFullPage(response: unknown): response is PageObjectResponse {
   return (
     typeof response === 'object' &&


### PR DESCRIPTION
### 🍥 ISSUE

- closed #62

---

### 🍥 Key Changes

- `src/constants/cache.ts`에 revalidate 상수 중앙 관리 (`REVALIDATE_LIST: 60s`, `REVALIDATE_DETAIL: 3600s`)
- 블로그/포트폴리오 목록 API Route에 ISR 적용 (60초 캐싱)
- 블로그/포트폴리오 상세 API Route 및 SSR 페이지에 ISR 적용 (1시간 캐싱)
- NavBar 데스크탑 메뉴 미노출 버그 수정 (`theme.media.desktop` 구간 추가)

---

### 🍥 ScreenShot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fixed navbar menu display to ensure navigation menu is properly visible and functional on desktop devices.

* **Performance**
  * Implemented intelligent content caching with adaptive revalidation schedules for blog and portfolio pages, improving load times and reducing server resource consumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->