### PR TITLE
Fix/#87/image-timeout-and-qualities

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,7 @@ const nextConfig: NextConfig = {
     emotion: true,
   },
   images: {
+    qualities: [75, 90],
     remotePatterns: [
       {
         protocol: 'https',

--- a/src/components/blog/BlogDetailContent.tsx
+++ b/src/components/blog/BlogDetailContent.tsx
@@ -11,7 +11,7 @@ import { theme } from '@/styles/theme';
 import TagList from '@/components/common/TagList';
 import { MarkdownBody, DetailMainTitle, DetailSubTitle, DetailDateBadge, DetailIconButton } from '@/styles/shared.styles';
 import { RiShareLine, RiArrowLeftLine } from '@remixicon/react';
-import { IMAGE_QUALITY } from '@/constants';
+
 import { useToast } from '@/components/common/Toast';
 import { copyToClipboard } from '@/utils/clipboard';
 import GiscusComments from '@/components/comments/GiscusComments';
@@ -129,7 +129,7 @@ function BlogDetailContent({ post }: BlogDetailContentProps) {
         {subtitle && <DetailSubTitle>{subtitle}</DetailSubTitle>}
         {thumbnail ? (
           <HeroImageWrapper>
-            <Image src={thumbnail} alt={title} fill sizes="(max-width: 800px) 100vw, 800px" quality={IMAGE_QUALITY} style={{ objectFit: 'cover' }} priority />
+            <Image src={thumbnail} alt={title} fill sizes="(max-width: 800px) 100vw, 800px" style={{ objectFit: 'cover' }} priority unoptimized />
           </HeroImageWrapper>
         ) : (
           <Placeholder />

--- a/src/components/comments/GiscusComments.tsx
+++ b/src/components/comments/GiscusComments.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef } from 'react';
 import styled from '@emotion/styled';
 import { theme } from '@/styles/theme';
 import { getGiscusConfig } from './giscusConfig';
@@ -28,10 +28,6 @@ export default function GiscusComments({ pageTitle, pagePath }: GiscusCommentsPr
   const giscusConfig = getGiscusConfig();
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const getTheme = useCallback(() => {
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-  }, []);
-
   useEffect(() => {
     if (!giscusConfig || !containerRef.current) return;
 
@@ -51,7 +47,7 @@ export default function GiscusComments({ pageTitle, pagePath }: GiscusCommentsPr
     script.setAttribute('data-reactions-enabled', '1');
     script.setAttribute('data-emit-metadata', '0');
     script.setAttribute('data-input-position', 'top');
-    script.setAttribute('data-theme', getTheme());
+    script.setAttribute('data-theme', window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
     script.setAttribute('data-lang', 'ko');
     script.setAttribute('data-loading', 'lazy');
     script.setAttribute('data-strict', '0');
@@ -73,7 +69,7 @@ export default function GiscusComments({ pageTitle, pagePath }: GiscusCommentsPr
       mediaQuery.removeEventListener('change', handleThemeChange);
       container.innerHTML = '';
     };
-  }, [giscusConfig, pagePath, pageTitle, getTheme]);
+  }, [pagePath, pageTitle]);
 
   if (!giscusConfig) {
     if (process.env.NODE_ENV === 'development') {

--- a/src/components/comments/GiscusComments.tsx
+++ b/src/components/comments/GiscusComments.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import Script from 'next/script';
+import { useEffect, useRef, useCallback } from 'react';
 import styled from '@emotion/styled';
 import { theme } from '@/styles/theme';
 import { getGiscusConfig } from './giscusConfig';
@@ -27,28 +26,54 @@ interface GiscusCommentsProps {
 
 export default function GiscusComments({ pageTitle, pagePath }: GiscusCommentsProps) {
   const giscusConfig = getGiscusConfig();
+  const containerRef = useRef<HTMLDivElement>(null);
 
-  const [giscusTheme, setGiscusTheme] = useState<'light' | 'dark'>('light');
+  const getTheme = useCallback(() => {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }, []);
 
   useEffect(() => {
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    const applyTheme = (event: MediaQueryListEvent | MediaQueryList) => {
-      const nextTheme = event.matches ? 'dark' : 'light';
-      setGiscusTheme(nextTheme);
+    if (!giscusConfig || !containerRef.current) return;
 
-      const iframe = document.querySelector<HTMLIFrameElement>('iframe.giscus-frame');
+    const container = containerRef.current;
+    container.innerHTML = '';
+
+    const mappingTerm = pageTitle?.trim() ? pageTitle.trim() : pagePath;
+
+    const script = document.createElement('script');
+    script.src = 'https://giscus.app/client.js';
+    script.setAttribute('data-repo', giscusConfig.repo);
+    script.setAttribute('data-repo-id', giscusConfig.repoId);
+    script.setAttribute('data-category', giscusConfig.category);
+    script.setAttribute('data-category-id', giscusConfig.categoryId);
+    script.setAttribute('data-mapping', 'pathname');
+    script.setAttribute('data-term', mappingTerm);
+    script.setAttribute('data-reactions-enabled', '1');
+    script.setAttribute('data-emit-metadata', '0');
+    script.setAttribute('data-input-position', 'top');
+    script.setAttribute('data-theme', getTheme());
+    script.setAttribute('data-lang', 'ko');
+    script.setAttribute('data-loading', 'lazy');
+    script.setAttribute('data-strict', '0');
+    script.crossOrigin = 'anonymous';
+    script.async = true;
+
+    container.appendChild(script);
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleThemeChange = (event: MediaQueryListEvent) => {
+      const nextTheme = event.matches ? 'dark' : 'light';
+      const iframe = container.querySelector<HTMLIFrameElement>('iframe.giscus-frame');
       iframe?.contentWindow?.postMessage({ giscus: { setConfig: { theme: nextTheme } } }, 'https://giscus.app');
     };
 
-    applyTheme(mediaQuery);
-    mediaQuery.addEventListener('change', applyTheme);
+    mediaQuery.addEventListener('change', handleThemeChange);
 
     return () => {
-      mediaQuery.removeEventListener('change', applyTheme);
+      mediaQuery.removeEventListener('change', handleThemeChange);
+      container.innerHTML = '';
     };
-  }, []);
-
-  const scriptKey = useMemo(() => `giscus-${pagePath.replace(/\//g, '-')}`, [pagePath]);
+  }, [giscusConfig, pagePath, pageTitle, getTheme]);
 
   if (!giscusConfig) {
     if (process.env.NODE_ENV === 'development') {
@@ -57,30 +82,9 @@ export default function GiscusComments({ pageTitle, pagePath }: GiscusCommentsPr
     return null;
   }
 
-  const mappingTerm = pageTitle?.trim() ? pageTitle.trim() : pagePath;
-
   return (
     <Section>
-      <GiscusContainer className="giscus" />
-      <Script
-        key={scriptKey}
-        src="https://giscus.app/client.js"
-        data-repo={giscusConfig.repo}
-        data-repo-id={giscusConfig.repoId}
-        data-category={giscusConfig.category}
-        data-category-id={giscusConfig.categoryId}
-        data-mapping="pathname"
-        data-term={mappingTerm}
-        data-reactions-enabled="1"
-        data-emit-metadata="0"
-        data-input-position="top"
-        data-theme={giscusTheme}
-        data-lang="ko"
-        data-loading="lazy"
-        data-strict="0"
-        crossOrigin="anonymous"
-        strategy="afterInteractive"
-      />
+      <GiscusContainer ref={containerRef} className="giscus" />
       <noscript>
         <Notice>댓글은 JavaScript 사용이 필요한 기능입니다.</Notice>
       </noscript>

--- a/src/components/portfolio/PortfolioDetailContent.tsx
+++ b/src/components/portfolio/PortfolioDetailContent.tsx
@@ -11,7 +11,7 @@ import TagList from '@/components/common/TagList';
 import CategoryBadge from '@/components/common/CategoryBadge';
 import { MarkdownBody, DetailMainTitle, DetailSubTitle, DetailDateBadge, DetailIconButton, DetailIconLink } from '@/styles/shared.styles';
 import { RiGithubFill, RiGlobalLine, RiShareLine } from '@remixicon/react';
-import { IMAGE_QUALITY } from '@/constants';
+
 import { useToast } from '@/components/common/Toast';
 import { copyToClipboard } from '@/utils/clipboard';
 import GiscusComments from '@/components/comments/GiscusComments';
@@ -125,7 +125,7 @@ function PortfolioDetailContent({ post }: PortfolioDetailContentProps) {
 
       {thumbnail && (
         <HeroImageWrapper>
-          <Image src={thumbnail} alt={title} fill sizes="(max-width: 800px) 100vw, 800px" quality={IMAGE_QUALITY} style={{ objectFit: 'cover' }} priority />
+          <Image src={thumbnail} alt={title} fill sizes="(max-width: 800px) 100vw, 800px" style={{ objectFit: 'cover' }} priority unoptimized />
         </HeroImageWrapper>
       )}
 

--- a/src/services/blog.service.ts
+++ b/src/services/blog.service.ts
@@ -50,29 +50,33 @@ export async function getBlogPosts(): Promise<BlogPost[] | null> {
   }
 }
 
-export const getBlogPost = unstable_cache(
+const fetchBlogPost = unstable_cache(
   async (id: string): Promise<BlogPostDetail | null> => {
     if (!id) throw new Error('Post ID is required');
 
-    try {
-      const [pageResponse, mdBlocks] = await Promise.all([notion.pages.retrieve({ page_id: id }), n2m.pageToMarkdown(id)]);
+    const [pageResponse, mdBlocks] = await Promise.all([notion.pages.retrieve({ page_id: id }), n2m.pageToMarkdown(id)]);
 
-      if (!isFullPage(pageResponse)) {
-        return null;
-      }
-
-      const metaData = parseBlogPost(pageResponse);
-      const mdString = n2m.toMarkdownString(mdBlocks);
-
-      return {
-        ...metaData,
-        content: mdString.parent,
-      };
-    } catch (error) {
-      console.error(`[BlogService] Failed to fetch post ${id}:`, error);
+    if (!isFullPage(pageResponse)) {
       return null;
     }
+
+    const metaData = parseBlogPost(pageResponse);
+    const mdString = n2m.toMarkdownString(mdBlocks);
+
+    return {
+      ...metaData,
+      content: mdString.parent,
+    };
   },
   ['blog-detail'],
   { revalidate: REVALIDATE_DETAIL },
 );
+
+export async function getBlogPost(id: string): Promise<BlogPostDetail | null> {
+  try {
+    return await fetchBlogPost(id);
+  } catch (error) {
+    console.error(`[BlogService] Failed to fetch post ${id}:`, error);
+    return null;
+  }
+}

--- a/src/services/portfolio.service.ts
+++ b/src/services/portfolio.service.ts
@@ -50,29 +50,33 @@ export async function getPortfolioPosts(): Promise<PortfolioPost[] | null> {
   }
 }
 
-export const getPortfolioPost = unstable_cache(
+const fetchPortfolioPost = unstable_cache(
   async (id: string): Promise<PortfolioDetail | null> => {
     if (!id) throw new Error('Portfolio ID is required');
 
-    try {
-      const [pageResponse, mdBlocks] = await Promise.all([notion.pages.retrieve({ page_id: id }), n2m.pageToMarkdown(id)]);
+    const [pageResponse, mdBlocks] = await Promise.all([notion.pages.retrieve({ page_id: id }), n2m.pageToMarkdown(id)]);
 
-      if (!isFullPage(pageResponse)) {
-        return null;
-      }
-
-      const metaData = parsePortfolioPage(pageResponse as PageObjectResponse);
-      const mdString = n2m.toMarkdownString(mdBlocks);
-
-      return {
-        ...metaData,
-        content: mdString.parent,
-      };
-    } catch (error) {
-      console.error(`[PortfolioService] Failed to fetch post ${id}:`, error);
+    if (!isFullPage(pageResponse)) {
       return null;
     }
+
+    const metaData = parsePortfolioPage(pageResponse as PageObjectResponse);
+    const mdString = n2m.toMarkdownString(mdBlocks);
+
+    return {
+      ...metaData,
+      content: mdString.parent,
+    };
   },
   ['portfolio-detail'],
   { revalidate: REVALIDATE_DETAIL },
 );
+
+export async function getPortfolioPost(id: string): Promise<PortfolioDetail | null> {
+  try {
+    return await fetchPortfolioPost(id);
+  } catch (error) {
+    console.error(`[PortfolioService] Failed to fetch post ${id}:`, error);
+    return null;
+  }
+}

--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -19,6 +19,7 @@ if (!process.env.NOTION_DB_PORTFOLIO_ID) {
 export const notion = new Client({
   auth: process.env.NOTION_API_KEY,
   notionVersion: '2025-09-03',
+  timeoutMs: 120_000,
 });
 
 export const BLOG_DB_ID = process.env.NOTION_DB_BLOG_ID || '';


### PR DESCRIPTION
### 🍥 ISSUE

- closed #87

---

### 🍥 Key Changes

- `next.config.ts`에 `images.qualities: [75, 90]` 추가 (Next.js 16 요구사항)
- Notion API 클라이언트 타임아웃 60초 → 120초로 확대
- 서비스 레이어 try/catch를 `unstable_cache` 바깥으로 이동하여 실패 결과 캐싱 방지
- 상세 페이지 hero image에 `unoptimized` 적용 (Notion S3 임시 URL 타임아웃 해결)
- Giscus 댓글 `next/script` → `useEffect` 방식으로 변경하여 클라이언트 네비게이션 시 안정적 렌더링

---

### 🍥 ScreenShot

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Adjusted image quality and optimization settings across blog and portfolio sections
  * Configured Notion API request timeout for improved reliability

* **Improvements**
  * Enhanced comments display with improved system theme synchronization and detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->