### PR TITLE
Refactor/#70/seo-metadata-and-url-constants

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,8 +1,22 @@
+import { Metadata } from 'next';
 import BlogContent from '@/components/blog/BlogContent';
 import { SectionTitle } from '@/styles/shared.styles';
 import { getBlogPosts } from '@/services/blog.service';
 
 export const revalidate = 60;
+
+export const metadata: Metadata = {
+  title: 'Blog',
+  description: 'zziglet의 개발 블로그 글 목록입니다.',
+  alternates: {
+    canonical: '/blog',
+  },
+  openGraph: {
+    title: 'Blog',
+    description: 'zziglet의 개발 블로그 글 목록입니다.',
+    url: '/blog',
+  },
+};
 
 export default async function BlogPage() {
   const posts = await getBlogPosts();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,8 +3,10 @@ import { suit } from '@/styles/fonts';
 import '@/styles/globals.css';
 import { EmotionThemeProvider } from '@/components/providers/EmotionThemeProvider';
 import { AppLayout } from '@/components/common/layout/AppLayout';
+import { BASE_URL } from '@/constants';
 
 export const metadata: Metadata = {
+  metadataBase: new URL(BASE_URL),
   title: 'zzig.log',
   description: 'zziglet의 좌충우돌 개발 생존기',
 };

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -1,8 +1,22 @@
+import { Metadata } from 'next';
 import PortfolioContent from '@/components/portfolio/PortfolioContent';
 import { SectionTitle } from '@/styles/shared.styles';
 import { getPortfolioPosts } from '@/services/portfolio.service';
 
 export const revalidate = 60;
+
+export const metadata: Metadata = {
+  title: 'Portfolio',
+  description: 'zziglet이 작업한 프로젝트를 모아둔 포트폴리오 페이지입니다.',
+  alternates: {
+    canonical: '/portfolio',
+  },
+  openGraph: {
+    title: 'Portfolio',
+    description: 'zziglet이 작업한 프로젝트를 모아둔 포트폴리오 페이지입니다.',
+    url: '/portfolio',
+  },
+};
 
 export default async function PortfolioPage() {
   const posts = await getPortfolioPosts();

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,4 +1,5 @@
 ﻿import type { MetadataRoute } from 'next';
+import { BASE_URL } from '@/constants';
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -7,6 +8,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: '/',
       disallow: '/private/',
     },
-    sitemap: 'https://zziglet.com/sitemap.xml',
+    sitemap: `${BASE_URL}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,21 +1,22 @@
 ﻿import type { MetadataRoute } from 'next';
+import { BASE_URL } from '@/constants';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: 'https://zziglet.com/',
+      url: BASE_URL,
       lastModified: new Date(),
       changeFrequency: 'yearly',
       priority: 1,
     },
     {
-      url: 'https://zziglet.com/blog',
+      url: `${BASE_URL}/blog`,
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
-      url: 'https://zziglet.com/portfolio',
+      url: `${BASE_URL}/portfolio`,
       lastModified: new Date(),
       changeFrequency: 'weekly',
       priority: 0.5,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,2 +1,2 @@
-export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+export const BASE_URL = (process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000').replace(/\/$/, '');
 export const IMAGE_QUALITY = 90;


### PR DESCRIPTION
### 🍥 ISSUE

- closed #70

---

### 🍥 Key Changes

- `sitemap.ts`, `robots.ts`의 하드코딩 URL을 `BASE_URL` 상수 기반으로 교체
- `BASE_URL` 상수에서 trailing slash를 제거하도록 정리해 URL 조합 시 중복 슬래시를 방지
- `layout.tsx`에 `metadataBase`를 추가해 App Router metadata URL 해석 기준을 통일
- `blog/page.tsx`, `portfolio/page.tsx`에 리스트 페이지용 metadata를 추가해 title, description, canonical, Open Graph 정보를 보강

---

### 🍥 ScreenShot

N/A
