### PR TITLE
Refactor/#68/modal-accessibility-and-loading-semantics

### DIFF
--- a/src/components/__tests__/accessibility.test.tsx
+++ b/src/components/__tests__/accessibility.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Loading from '@/components/common/Loading';
+import PortfolioDetailModal from '@/components/portfolio/PortfolioDetailModal';
+import { PortfolioDetail } from '@/types/portfolio';
+
+const post: PortfolioDetail = {
+  id: 'portfolio-id',
+  title: '접근성 테스트 프로젝트',
+  description: 'description',
+  thumbnail: null,
+  category: 'Frontend',
+  tags: ['React'],
+  githubUrl: null,
+  webUrl: null,
+  startDate: '2025-01-01',
+  endDate: null,
+  content: 'content',
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('accessibility improvements', () => {
+  it('exposes loading status semantics', () => {
+    render(<Loading />);
+
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+    expect(screen.getByText('로딩 중')).toBeInTheDocument();
+  });
+
+  it('applies dialog semantics and closes on Escape', () => {
+    const onClose = vi.fn();
+
+    render(<PortfolioDetailModal isOpen onClose={onClose} post={post} />);
+
+    expect(screen.getByRole('dialog', { name: post.title })).toHaveAttribute('aria-modal', 'true');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('traps focus within the modal', () => {
+    render(<PortfolioDetailModal isOpen onClose={vi.fn()} post={post} />);
+
+    const dialog = screen.getByRole('dialog', { name: post.title });
+    const openPageLink = screen.getByRole('link', { name: '전체 페이지로 보기' });
+    const focusableElements = Array.from(dialog.querySelectorAll<HTMLElement>('a[href], button'));
+    const lastFocusableElement = focusableElements[focusableElements.length - 1];
+
+    expect(openPageLink).toHaveFocus();
+
+    lastFocusableElement.focus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(openPageLink).toHaveFocus();
+
+    openPageLink.focus();
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(lastFocusableElement).toHaveFocus();
+  });
+});

--- a/src/components/common/Loading.tsx
+++ b/src/components/common/Loading.tsx
@@ -28,12 +28,25 @@ const Dot = styled.div<{ delay: string }>`
   }
 `;
 
+const VisuallyHiddenText = styled.span`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+`;
+
 function Loading() {
   return (
-    <Container>
-      <Dot delay="0s" />
-      <Dot delay="0.2s" />
-      <Dot delay="0.4s" />
+    <Container role="status" aria-live="polite">
+      <VisuallyHiddenText>로딩 중</VisuallyHiddenText>
+      <Dot delay="0s" aria-hidden="true" />
+      <Dot delay="0.2s" aria-hidden="true" />
+      <Dot delay="0.4s" aria-hidden="true" />
     </Container>
   );
 }

--- a/src/components/portfolio/PortfolioDetailModal.tsx
+++ b/src/components/portfolio/PortfolioDetailModal.tsx
@@ -1,6 +1,6 @@
 ﻿'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useId, useRef } from 'react';
 import styled from '@emotion/styled';
 import Link from 'next/link';
 import { theme } from '@/styles/theme';
@@ -126,6 +126,18 @@ const ScrollArea = styled.div`
   }
 `;
 
+const VisuallyHiddenTitle = styled.h2`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+`;
+
 interface PortfolioModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -133,27 +145,80 @@ interface PortfolioModalProps {
 }
 
 function PortfolioDetailModal({ isOpen, onClose, post }: PortfolioModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const previousActiveElementRef = useRef<HTMLElement | null>(null);
+  const titleId = useId();
+
   useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'unset';
-    }
-    return () => {
-      document.body.style.overflow = 'unset';
+    if (!isOpen || !post) return;
+
+    previousActiveElementRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    document.body.style.overflow = 'hidden';
+
+    const modalElement = modalRef.current;
+    const getFocusableElements = () =>
+      modalElement
+        ? Array.from(
+            modalElement.querySelectorAll<HTMLElement>(
+              'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+            ),
+          )
+        : [];
+
+    const focusableElements = getFocusableElements();
+    (focusableElements[0] ?? modalElement)?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== 'Tab') return;
+
+      const elements = getFocusableElements();
+      if (elements.length === 0) {
+        event.preventDefault();
+        modalElement?.focus();
+        return;
+      }
+
+      const firstElement = elements[0];
+      const lastElement = elements[elements.length - 1];
+      const activeElement = document.activeElement;
+
+      if (event.shiftKey && (activeElement === firstElement || activeElement === modalElement)) {
+        event.preventDefault();
+        lastElement.focus();
+      }
+
+      if (!event.shiftKey && activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
     };
-  }, [isOpen]);
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = 'unset';
+      previousActiveElementRef.current?.focus();
+    };
+  }, [isOpen, onClose, post]);
 
   if (!isOpen || !post) return null;
 
   return (
     <Backdrop onClick={onClose}>
-      <ModalContainer onClick={(e) => e.stopPropagation()}>
+      <ModalContainer ref={modalRef} role="dialog" aria-modal="true" aria-labelledby={titleId} tabIndex={-1} onClick={(e) => e.stopPropagation()}>
+        <VisuallyHiddenTitle id={titleId}>{post.title}</VisuallyHiddenTitle>
         <ModalHeader>
-          <ControlLink href={`/portfolio/${post.id}`} title="전체 페이지로 보기">
+          <ControlLink href={`/portfolio/${post.id}`} title="전체 페이지로 보기" aria-label="전체 페이지로 보기">
             <RiFullscreenLine size={24} />
           </ControlLink>
-          <ControlButton onClick={onClose} title="닫기">
+          <ControlButton type="button" onClick={onClose} title="닫기" aria-label="닫기">
             <RiCloseLine size={24} />
           </ControlButton>
         </ModalHeader>


### PR DESCRIPTION
### 🍥 ISSUE

- closed #68

---

### 🍥 Key Changes

- `PortfolioDetailModal`에 `role="dialog"`, `aria-modal`, `aria-labelledby`를 추가해 대화상자 시맨틱을 보강
- modal open 시 첫 포커서블 요소로 포커스를 이동시키고, `Tab`/`Shift+Tab`으로 modal 내부 포커스가 순환되도록 focus trap을 구현
- `Escape` 키로 modal을 닫고, 닫힐 때 이전 포커스로 복귀하도록 키보드 접근성을 개선
- `Loading` 컴포넌트에 `role="status"`, `aria-live="polite"`와 숨김 로딩 텍스트를 추가
- modal/loading 접근성 동작을 검증하는 테스트를 추가

---

### 🍥 ScreenShot

N/A
