### PR TITLE
Refactor/#71/security-headers-expansion

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,10 +10,11 @@ const contentSecurityPolicy = [
   "font-src 'self' data:",
   "connect-src 'self' https://api.github.com https://github.com https://giscus.app",
   'frame-src https://giscus.app',
-  "frame-ancestors 'self'",
+  "frame-ancestors 'none'",
   "object-src 'none'",
   "base-uri 'self'",
   "form-action 'self'",
+  ...(isDev ? [] : ['upgrade-insecure-requests']),
 ].join('; ');
 
 const nextConfig: NextConfig = {
@@ -47,7 +48,7 @@ const nextConfig: NextConfig = {
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
           {
             key: 'Strict-Transport-Security',
-            value: 'max-age=31536000; includeSubDomains; preload',
+            value: 'max-age=63072000; includeSubDomains; preload',
           },
           {
             key: 'Content-Security-Policy',


### PR DESCRIPTION
### 🍥 ISSUE

- closed #71

---

### 🍥 Key Changes

- `next.config.ts`의 CSP에서 `frame-ancestors`를 `'none'`으로 강화해 외부 페이지 임베딩을 차단
- production 환경에서만 `upgrade-insecure-requests`를 적용해 HTTPS 강제를 보강
- `Strict-Transport-Security`의 `max-age`를 `63072000`으로 상향해 HSTS 정책을 강화
- 기존 `Permissions-Policy`, `Cross-Origin-Opener-Policy`, Giscus 관련 CSP 허용 범위는 유지해 현재 동작과 호환되도록 정리

---

### 🍥 ScreenShot

N/A
